### PR TITLE
🛠 fix: inexistent method on Schedule

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -28,7 +28,7 @@ while True:
     nfc_list = acc.split()
 
     if all(map(valid_nrc, nfc_list)):
-        RESULTS = Schedule.get_courses(nfc_list)
+        RESULTS = Schedule.get(nfc_list)
         print("Cursos importados:", *RESULTS.courses, sep="\n", end="\n" * 2)
 
         print("Cargar el siguiente calendario?")


### PR DESCRIPTION
```shell
➜ python src/main.py                                        23:29:11

█▙  █ ███▖ ▟██▙             ▐▌
██▙ █ █  █ █▘      ▗▄▄▖    ▄▄▖  ▗▄▄▖ ▗▄▄▖
█▝█▙█ ███▛ █       ▘  █    ▀▜▌  █▛▀▀ █▀▀▀
█ ▝██ █ ▝▙ █▖      ▟▀▜█     ▐▌  █▖   ▝▀▀█
█  ▝█ █  █ ▜██▛    ▜▃▞█    ████ ▜██▛ ▜██▛

Ingresar los NRC separados por espacios

NRC -> 22590
Traceback (most recent call last):
  File "src/main.py", line 31, in <module>
    RESULTS = Schedule.get_courses(nfc_list)
AttributeError: type object 'Schedule' has no attribute 'get_courses'
```

Viendo la clase `Schedule`, me imagino que la intención era usar el método `get()`, no `get_courses()`. Parece solucionarlo.